### PR TITLE
fix: use timeout keyword in force_flush + shutdown

### DIFF
--- a/lib/pyroscope/otel.rb
+++ b/lib/pyroscope/otel.rb
@@ -59,9 +59,9 @@ module Pyroscope
         Pyroscope._remove_tags(Pyroscope.thread_id, labels)
       end
 
-      def force_flush(_timeout: nil) end
+      def force_flush(timeout: nil) end
 
-      def shutdown(_timeout: nil) end
+      def shutdown(timeout: nil) end
 
       private
 

--- a/lib/pyroscope/otel.rb
+++ b/lib/pyroscope/otel.rb
@@ -59,9 +59,13 @@ module Pyroscope
         Pyroscope._remove_tags(Pyroscope.thread_id, labels)
       end
 
-      def force_flush(timeout: nil) end
+      def force_flush(timeout: nil)
+        0
+      end
 
-      def shutdown(timeout: nil) end
+      def shutdown(timeout: nil)
+        0
+      end
 
       private
 


### PR DESCRIPTION
The original implementation does not conform to the interface required by OpenTel ([documentation](https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-sdk/v1.0.3/OpenTelemetry/SDK/Trace/SpanProcessor.html)). This results in errors during span shutdown `unknown keyword: :timeout (ArgumentError)`. Additionally, the spec specifies that an integer should be returned, 0 for success.