### PR TITLE
Fix linting

### DIFF
--- a/lib/pyroscope/otel.rb
+++ b/lib/pyroscope/otel.rb
@@ -59,12 +59,12 @@ module Pyroscope
         Pyroscope._remove_tags(Pyroscope.thread_id, labels)
       end
 
-      def force_flush(timeout: nil)
-        0
+      def force_flush(*)
+        OpenTelemetry::SDK::Trace::Export::SUCCESS
       end
 
-      def shutdown(timeout: nil)
-        0
+      def shutdown(*)
+        OpenTelemetry::SDK::Trace::Export::SUCCESS
       end
 
       private


### PR DESCRIPTION
Fixes the linting issue with unused parameters. Also uses the OTEL constants instead of the ints.

Follow up to #6 