### PR TITLE
Switch release workflow to trusted publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-x64
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         persist-credentials: false
     - name: Set up Ruby

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,14 +13,14 @@ jobs:
   push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
           bundler-cache: true
           ruby-version: ruby
 
-      - uses: rubygems/release-gem@v1
+      - uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,6 @@ jobs:
         with:
           ruby-version: ruby
 
+      - run: bundle install
+
       - uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
-          bundler-cache: true
           ruby-version: ruby
 
       - uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - v*
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,32 +2,25 @@ name: Publish Gem
 
 on:
   push:
-    branches:
-      - "*"
     tags:
       - v*
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
-  build:
-    runs-on: ubuntu-x64
-
+  push:
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - name: Configure git
-        run: |
-          git config user.name "Pyroscope Bot"
-          git config user.email "dmitry+bot@pyroscope.io"
 
-      - name: Release Gem
-        uses: cadwallion/publish-rubygems-action@94a6f4cd5350581749c569b5001eecc864e3ad0b
-        if: contains(github.ref, 'refs/tags/v')
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
-          RELEASE_COMMAND: rake build release:source_control_push release:rubygem_push 
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      - uses: rubygems/release-gem@v1


### PR DESCRIPTION
## Summary

Replace `cadwallion/publish-rubygems-action` with `rubygems/release-gem@v1`, which uses OIDC-based trusted publishing to authenticate with RubyGems.org instead of a long-lived API key.

## Changes

- Use `rubygems/release-gem@v1` for publishing, which handles the OIDC token exchange automatically
- Remove `RUBYGEMS_API_KEY` and `GITHUB_TOKEN` secrets from the workflow — no credentials needed
- Remove the `push.branches: ["*"]` trigger (the release job only needs to run on version tags)
- Remove the manual git config step (no longer needed)
- Use `ruby/setup-ruby@v1` with `bundler-cache: true` for dependency installation
- Update `actions/checkout` to v5 and runner to `ubuntu-latest`

## Before merging

A trusted publisher must be configured on RubyGems.org for the `pyroscope-otel` gem:

1. Go to the gem's page on RubyGems.org → Trusted publishers
2. Add a publisher with owner `grafana`, repo `otel-profiling-ruby`, workflow `release.yml`

After the first successful release, the `RUBYGEMS_API_KEY` repository secret can be removed.