### PR TITLE
Bump pyroscope dependency to 1.x

### DIFF
--- a/lib/pyroscope/otel.rb
+++ b/lib/pyroscope/otel.rb
@@ -43,7 +43,7 @@ module Pyroscope
         labels = { "profile_id": profile_id }
         labels["span"] = span.name if @add_span_name
 
-        Pyroscope._add_tags(Pyroscope.thread_id, labels)
+        Pyroscope._add_tags(labels)
 
         annotate_span(profile_id, span)
       rescue StandardError => e
@@ -56,7 +56,7 @@ module Pyroscope
 
         labels = { "profile_id": profile_id }
         labels["span"] = span.name if @add_span_name
-        Pyroscope._remove_tags(Pyroscope.thread_id, labels)
+        Pyroscope._remove_tags(labels)
       end
 
       def force_flush(*)

--- a/lib/pyroscope/otel/version.rb
+++ b/lib/pyroscope/otel/version.rb
@@ -2,6 +2,6 @@
 
 module Pyroscope
   module Otel
-    VERSION = "0.1.4"
+    VERSION = "0.2.0"
   end
 end

--- a/pyroscope-otel.gemspec
+++ b/pyroscope-otel.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "opentelemetry-api", "~> 1.1"
-  spec.add_dependency "pyroscope", ">= 0.5.1", "< 1.0"
+  spec.add_dependency "pyroscope", ">= 1.0", "< 2.0"
 end


### PR DESCRIPTION
## Summary
- The `pyroscope` gem 1.0 removed `Pyroscope.thread_id` and changed `_add_tags` / `_remove_tags` from a 2-arg `(thread_id, tags)` signature to a 1-arg `(tags)` signature (in fact since 0.6.9). The existing `SpanProcessor` calls raise `NoMethodError` against `pyroscope >= 0.6.9`.
- Update the two call sites in `lib/pyroscope/otel.rb` to the new 1-arg form.
- Raise the gemspec dependency floor: `pyroscope` `>= 1.0, < 2.0`.
- Bump gem version `0.1.4` → `0.2.0`.

The previous dependency range `>= 0.5.1, < 1.0` was effectively `>= 0.5.1, <= 0.6.7` in practice — the 0.6.9+ releases already broke the integration silently.

## Test plan
Smoke-tested manually against the installed gem:
- `pyroscope 1.0.1` + edited `SpanProcessor`: `on_start` / `on_finish` complete without raising and the `pyroscope.profile.id` / `pyroscope.profile.url` span attributes are set.
- `pyroscope 1.0.1` + previous (2-arg) call pattern: `NoMethodError: undefined method 'thread_id' for Pyroscope:Module` (confirms the previous state was broken).