### PR TITLE
fix(release): skip git push in rake release to fix detached-HEAD CI failure

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,11 +4,11 @@ require "bundler/gem_tasks"
 
 # release-please already creates the git tag and GitHub release. The
 # rubygems/release-gem action runs `bundle exec rake release`, which would
-# otherwise try to `git push` — that fails in CI because the repo is checked
+# otherwise try to `git push` -- that fails in CI because the repo is checked
 # out at a detached SHA with no credentials. Skip the SCM push and let
 # `rake release` only publish the gem to rubygems.org.
 module Bundler
-  class GemHelper
+  class GemHelper # rubocop:disable Style/Documentation
     def perform_git_push(*); end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,18 @@
 # frozen_string_literal: true
 
 require "bundler/gem_tasks"
+
+# release-please already creates the git tag and GitHub release. The
+# rubygems/release-gem action runs `bundle exec rake release`, which would
+# otherwise try to `git push` — that fails in CI because the repo is checked
+# out at a detached SHA with no credentials. Skip the SCM push and let
+# `rake release` only publish the gem to rubygems.org.
+module Bundler
+  class GemHelper
+    def perform_git_push(*); end
+  end
+end
+
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)


### PR DESCRIPTION
## Problem

The `Publish Gem` job in `release-please.yml` failed ([run](https://github.com/grafana/otel-profiling-ruby/actions/runs/26753003964/job/78845600242)):

```
pyroscope-otel 0.2.1 built to pkg/pyroscope-otel-0.2.1.gem.
Tagged v0.2.1.
Untagging v0.2.1 due to error.
rake aborted!
Running `git push origin refs/heads/HEAD` failed
error: src refspec refs/heads/HEAD does not match any
Tasks: TOP => release => release:source_control_push
```

The `rubygems/release-gem` action runs `bundle exec rake release`. Bundler's `release` task runs `release:source_control_push` (a `git push` of the branch + tag) *before* `release:rubygem_push`. The publish job checks out a specific SHA (`ref: needs.release-please.outputs.sha`) with `persist-credentials: false`, leaving the repo in **detached-HEAD** state, so `current_branch` resolves to the literal `HEAD` and the push fails.

Two consequences:
- The gem was **never pushed to rubygems.org** (the git push fails first).
- The git push is redundant anyway — release-please already creates the tag and GitHub release.

## Fix

Override `Bundler::GemHelper#perform_git_push` to a no-op so `rake release` only publishes the gem to rubygems.org.

## Follow-up

0.2.1 never published to rubygems.org. After merging, the publish needs to be re-run for v0.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)