### PR TITLE
test: add Go-based integration test for span profiles

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,0 +1,71 @@
+name: Integration Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    name: discover tests
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.tests.outputs.tests }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version: 'stable'
+          cache-dependency-path: integration-test/go.mod
+      - name: Generate test matrix
+        id: tests
+        run: echo "tests=$(make ci-matrix)" >> "$GITHUB_OUTPUT"
+        working-directory: integration-test
+
+  unit-test:
+    name: dockertest unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version: 'stable'
+          cache-dependency-path: integration-test/go.mod
+      - name: Run dockertest unit tests
+        run: go test -v -timeout 10m ./dockertest/
+        working-directory: integration-test
+
+  test:
+    name: integration-test ${{ matrix.test }} ruby ${{ matrix.ruby_version }}
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test: ${{ fromJSON(needs.discover.outputs.tests) }}
+        ruby_version: ['3.2.2', '3.3.9', '3.4.1']
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version: 'stable'
+          cache-dependency-path: integration-test/go.mod
+      - name: Run integration test
+        run: go test -v -timeout 60m -count=1 -run "^${{ matrix.test }}$" .
+        env:
+          RUBY_VERSION: ${{ matrix.ruby_version }}
+        working-directory: integration-test

--- a/integration-test/Makefile
+++ b/integration-test/Makefile
@@ -1,0 +1,9 @@
+REPO_ROOT := $(shell git rev-parse --show-toplevel)
+
+.PHONY: ci-matrix
+ci-matrix:
+	@go test -list . -json . | jq -sc '[.[] | select(.Action=="output") | .Output | rtrimstr("\n") | select(startswith("Test"))]'
+
+.PHONY: test/%
+test/%:
+	go test -v -timeout 60m -count=1 -run '^$*$$' ./...

--- a/integration-test/api/querier/client.go
+++ b/integration-test/api/querier/client.go
@@ -1,0 +1,83 @@
+package querier
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type Client struct {
+	HTTP *http.Client
+	URL  string
+}
+
+func NewClient(client *http.Client, url string) *Client {
+	return &Client{
+		HTTP: client,
+		URL:  url,
+	}
+}
+
+func (c *Client) SelectMergeStacktraces(ctx context.Context, req *SelectMergeStacktracesRequest) (*SelectMergeStacktracesResponse, error) {
+	url := c.URL + "/querier.v1.QuerierService/SelectMergeStacktraces"
+	bs, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("faield to marshal request to json: %w", err)
+	}
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(bs))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create http request: %w", err)
+	}
+	httpRequest.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HTTP.Do(httpRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to do http request: %w", err)
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("server returned %d %s", resp.StatusCode, responseBody)
+	}
+	res := new(SelectMergeStacktracesResponse)
+	err = json.Unmarshal(responseBody, res)
+	return res, err
+}
+
+type ProfileFormat int32
+
+const (
+	ProfileFormat_PROFILE_FORMAT_UNSPECIFIED ProfileFormat = 0
+	ProfileFormat_PROFILE_FORMAT_FLAMEGRAPH  ProfileFormat = 1
+	ProfileFormat_PROFILE_FORMAT_TREE        ProfileFormat = 2
+)
+
+type SelectMergeStacktracesRequest struct {
+	// Profile Type ID string in the form
+	// <name>:<type>:<unit>:<period_type>:<period_unit>.
+	ProfileTypeID string `json:"profile_typeID,omitempty"`
+	// Label selector string
+	LabelSelector string `json:"label_selector,omitempty"`
+	// Milliseconds since epoch.
+	Start int64 `json:"start,omitempty"`
+	// Milliseconds since epoch.
+	End int64 `json:"end,omitempty"`
+	// Limit the nodes returned to only show the node with the max_node's biggest
+	// total
+	MaxNodes *int64 `json:"max_nodes,omitempty"`
+	// Profile format specifies the format of profile to be returned.
+	// If not specified, the profile will be returned in flame graph format.
+	Format ProfileFormat `json:"format,omitempty"`
+	// Select stack traces that match the provided selector.
+	//StackTraceSelector *v1.StackTraceSelector `protobuf:"bytes,7,opt,name=stack_trace_selector,json=stackTraceSelector,proto3,oneof" json:"stack_trace_selector,omitempty"`
+	// List of Profile UUIDs to query
+	ProfileIdSelector []string `json:"profile_id_selector,omitempty"`
+}
+
+type SelectMergeStacktracesResponse struct {
+	// Pyroscope tree bytes.
+	Tree []byte `json:"tree,omitempty"`
+}

--- a/integration-test/api/querier/client.go
+++ b/integration-test/api/querier/client.go
@@ -47,6 +47,32 @@ func (c *Client) SelectMergeStacktraces(ctx context.Context, req *SelectMergeSta
 	return res, err
 }
 
+func (c *Client) SelectMergeSpanProfile(ctx context.Context, req *SelectMergeSpanProfileRequest) (*SelectMergeSpanProfileResponse, error) {
+	url := c.URL + "/querier.v1.QuerierService/SelectMergeSpanProfile"
+	bs, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("faield to marshal request to json: %w", err)
+	}
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(bs))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create http request: %w", err)
+	}
+	httpRequest.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HTTP.Do(httpRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to do http request: %w", err)
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("server returned %d %s", resp.StatusCode, responseBody)
+	}
+	res := new(SelectMergeSpanProfileResponse)
+	err = json.Unmarshal(responseBody, res)
+	return res, err
+}
+
 type ProfileFormat int32
 
 const (
@@ -78,6 +104,31 @@ type SelectMergeStacktracesRequest struct {
 }
 
 type SelectMergeStacktracesResponse struct {
+	// Pyroscope tree bytes.
+	Tree []byte `json:"tree,omitempty"`
+}
+
+type SelectMergeSpanProfileRequest struct {
+	// Profile Type ID string in the form
+	// <name>:<type>:<unit>:<period_type>:<period_unit>.
+	ProfileTypeID string `json:"profile_typeID,omitempty"`
+	// Label selector string
+	LabelSelector string `json:"label_selector,omitempty"`
+	// Milliseconds since epoch.
+	Start int64 `json:"start,omitempty"`
+	// Milliseconds since epoch.
+	End int64 `json:"end,omitempty"`
+	// Select profiles whose samples are tagged with one of the provided span IDs.
+	SpanSelector []string `json:"span_selector,omitempty"`
+	// Limit the nodes returned to only show the node with the max_node's biggest
+	// total
+	MaxNodes *int64 `json:"max_nodes,omitempty"`
+	// Profile format specifies the format of profile to be returned.
+	// If not specified, the profile will be returned in flame graph format.
+	Format ProfileFormat `json:"format,omitempty"`
+}
+
+type SelectMergeSpanProfileResponse struct {
 	// Pyroscope tree bytes.
 	Tree []byte `json:"tree,omitempty"`
 }

--- a/integration-test/app/Dockerfile
+++ b/integration-test/app/Dockerfile
@@ -1,0 +1,18 @@
+ARG RUBY_VERSION=3.3.9
+FROM ruby:${RUBY_VERSION}
+
+WORKDIR /opt/app
+
+# Copy the gem under test (build context is the repo root).
+COPY lib /opt/gem/lib
+COPY pyroscope-otel.gemspec /opt/gem/pyroscope-otel.gemspec
+
+COPY integration-test/app/Gemfile ./Gemfile
+RUN bundle install
+
+COPY integration-test/app/lib ./lib
+
+ENV APP_ENV=production
+
+# `bundle exec` is required so the `pyroscope-otel` path gem is on the load path.
+CMD ["bundle", "exec", "ruby", "lib/main.rb"]

--- a/integration-test/app/Gemfile
+++ b/integration-test/app/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# The gem under test, mounted from the repo root in the Dockerfile.
+gem "pyroscope-otel", path: "/opt/gem"
+
+gem "pyroscope", "~> 1.0"
+gem "opentelemetry-sdk"

--- a/integration-test/app/Gemfile
+++ b/integration-test/app/Gemfile
@@ -2,8 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "opentelemetry-sdk"
+gem "pyroscope", "~> 1.0"
 # The gem under test, mounted from the repo root in the Dockerfile.
 gem "pyroscope-otel", path: "/opt/gem"
-
-gem "pyroscope", "~> 1.0"
-gem "opentelemetry-sdk"

--- a/integration-test/app/lib/main.rb
+++ b/integration-test/app/lib/main.rb
@@ -4,6 +4,11 @@ require "pyroscope"
 require "pyroscope/otel"
 require "opentelemetry-sdk"
 
+warn "DIAG pyroscope-otel spec: #{Gem.loaded_specs['pyroscope-otel']&.full_gem_path.inspect} version=#{Gem.loaded_specs['pyroscope-otel']&.version}"
+warn "DIAG SpanProcessor#initialize source: #{Pyroscope::Otel::SpanProcessor.instance_method(:initialize).source_location.inspect}"
+warn "DIAG loaded otel features: #{$LOADED_FEATURES.grep(/pyroscope.*otel/).inspect}"
+warn "DIAG load paths (gem/opt): #{$LOAD_PATH.grep(%r{/opt/gem|pyroscope-otel}).inspect}"
+
 app_name = ENV.fetch("PYROSCOPE_APPLICATION_NAME", "rideshare.ruby.app")
 server = ENV.fetch("PYROSCOPE_SERVER_ADDRESS", "http://pyroscope:4040")
 

--- a/integration-test/app/lib/main.rb
+++ b/integration-test/app/lib/main.rb
@@ -8,6 +8,9 @@ warn "DIAG pyroscope-otel spec: #{Gem.loaded_specs['pyroscope-otel']&.full_gem_p
 warn "DIAG SpanProcessor#initialize source: #{Pyroscope::Otel::SpanProcessor.instance_method(:initialize).source_location.inspect}"
 warn "DIAG loaded otel features: #{$LOADED_FEATURES.grep(/pyroscope.*otel/).inspect}"
 warn "DIAG load paths (gem/opt): #{$LOAD_PATH.grep(%r{/opt/gem|pyroscope-otel}).inspect}"
+warn "DIAG SpanProcessor instance_methods(false): #{Pyroscope::Otel::SpanProcessor.instance_methods(false).inspect}"
+warn "DIAG otel.rb on disk (first 40 lines):"
+warn File.read("/opt/gem/lib/pyroscope/otel.rb").lines.first(40).map { |l| "  | #{l.rstrip}" }.join("\n")
 
 app_name = ENV.fetch("PYROSCOPE_APPLICATION_NAME", "rideshare.ruby.app")
 server = ENV.fetch("PYROSCOPE_SERVER_ADDRESS", "http://pyroscope:4040")

--- a/integration-test/app/lib/main.rb
+++ b/integration-test/app/lib/main.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "pyroscope"
+require "pyroscope/otel"
+require "opentelemetry-sdk"
+
+app_name = ENV.fetch("PYROSCOPE_APPLICATION_NAME", "rideshare.ruby.app")
+server = ENV.fetch("PYROSCOPE_SERVER_ADDRESS", "http://pyroscope:4040")
+
+Pyroscope.configure do |config|
+  config.app_name = app_name
+  config.server_address = server
+  config.tags = {
+    "region": ENV.fetch("REGION", "us-east")
+  }
+end
+
+OpenTelemetry::SDK.configure do |c|
+  c.add_span_processor Pyroscope::Otel::SpanProcessor.new("#{app_name}.cpu", server)
+end
+
+# spin busy-loops for roughly `seconds` so the CPU profiler captures the frame.
+def spin(seconds)
+  start = Time.now
+  i = 0
+  i += 1 while Time.now - start < seconds
+  i
+end
+
+def check_driver_availability(seconds)
+  spin(seconds / 2.0)
+end
+
+def find_nearest_vehicle(seconds, vehicle)
+  Pyroscope.tag_wrapper({ "vehicle" => vehicle }) do
+    spin(seconds)
+    check_driver_availability(seconds) if vehicle == "car"
+  end
+end
+
+def order_bike(seconds)
+  find_nearest_vehicle(seconds, "bike")
+end
+
+def order_scooter(seconds)
+  find_nearest_vehicle(seconds, "scooter")
+end
+
+def order_car(seconds)
+  find_nearest_vehicle(seconds, "car")
+end
+
+tracer = OpenTelemetry.tracer_provider.tracer("rideshare")
+
+puts "rideshare ruby app started: app_name=#{app_name} server=#{server}"
+$stdout.flush
+
+loop do
+  tracer.in_span("BikeHandler") { order_bike(0.2) }
+  tracer.in_span("ScooterHandler") { order_scooter(0.3) }
+  tracer.in_span("CarHandler") { order_car(0.4) }
+end

--- a/integration-test/app/lib/main.rb
+++ b/integration-test/app/lib/main.rb
@@ -78,5 +78,9 @@ $stdout.flush
 loop do
   tracer.in_span("BikeHandler") { order_bike(0.2) }
   tracer.in_span("ScooterHandler") { order_scooter(0.3) }
-  tracer.in_span("CarHandler") { order_car(0.4) }
+  tracer.in_span("CarHandler") do |span|
+    order_car(0.4)
+    puts "span=CarHandler spanId=#{span.context.span_id.unpack1('H*')}"
+    $stdout.flush
+  end
 end

--- a/integration-test/app/lib/main.rb
+++ b/integration-test/app/lib/main.rb
@@ -15,8 +15,28 @@ Pyroscope.configure do |config|
   }
 end
 
+# Print the underlying cause of any configuration error so failures are
+# diagnosable from the container logs instead of the opaque SDK wrapper.
+OpenTelemetry.error_handler = lambda do |exception:, message:|
+  warn "OpenTelemetry error: #{message}"
+  if exception
+    warn "  #{exception.class}: #{exception.message}"
+    cause = exception.cause
+    if cause
+      warn "  caused by #{cause.class}: #{cause.message}"
+      warn cause.backtrace.first(15).map { |l| "    #{l}" }.join("\n") if cause.backtrace
+    end
+  end
+end
+
 OpenTelemetry::SDK.configure do |c|
   c.add_span_processor Pyroscope::Otel::SpanProcessor.new("#{app_name}.cpu", server)
+end
+
+provider = OpenTelemetry.tracer_provider
+unless provider.is_a?(OpenTelemetry::SDK::Trace::TracerProvider)
+  warn "FATAL: OpenTelemetry SDK did not configure; tracer_provider=#{provider.class}. Spans will not be recorded."
+  exit 1
 end
 
 # spin busy-loops for roughly `seconds` so the CPU profiler captures the frame.

--- a/integration-test/app/lib/main.rb
+++ b/integration-test/app/lib/main.rb
@@ -4,14 +4,6 @@ require "pyroscope"
 require "pyroscope/otel"
 require "opentelemetry-sdk"
 
-warn "DIAG pyroscope-otel spec: #{Gem.loaded_specs['pyroscope-otel']&.full_gem_path.inspect} version=#{Gem.loaded_specs['pyroscope-otel']&.version}"
-warn "DIAG SpanProcessor#initialize source: #{Pyroscope::Otel::SpanProcessor.instance_method(:initialize).source_location.inspect}"
-warn "DIAG loaded otel features: #{$LOADED_FEATURES.grep(/pyroscope.*otel/).inspect}"
-warn "DIAG load paths (gem/opt): #{$LOAD_PATH.grep(%r{/opt/gem|pyroscope-otel}).inspect}"
-warn "DIAG SpanProcessor instance_methods(false): #{Pyroscope::Otel::SpanProcessor.instance_methods(false).inspect}"
-warn "DIAG otel.rb on disk (first 40 lines):"
-warn File.read("/opt/gem/lib/pyroscope/otel.rb").lines.first(40).map { |l| "  | #{l.rstrip}" }.join("\n")
-
 app_name = ENV.fetch("PYROSCOPE_APPLICATION_NAME", "rideshare.ruby.app")
 server = ENV.fetch("PYROSCOPE_SERVER_ADDRESS", "http://pyroscope:4040")
 
@@ -38,7 +30,7 @@ OpenTelemetry.error_handler = lambda do |exception:, message:|
 end
 
 OpenTelemetry::SDK.configure do |c|
-  c.add_span_processor Pyroscope::Otel::SpanProcessor.new("#{app_name}.cpu", server)
+  c.add_span_processor Pyroscope::Otel::SpanProcessor.new
 end
 
 provider = OpenTelemetry.tracer_provider

--- a/integration-test/app/lib/main.rb
+++ b/integration-test/app/lib/main.rb
@@ -80,7 +80,7 @@ loop do
   tracer.in_span("ScooterHandler") { order_scooter(0.3) }
   tracer.in_span("CarHandler") do |span|
     order_car(0.4)
-    puts "span=CarHandler spanId=#{span.context.span_id.unpack1('H*')}"
+    puts "span=CarHandler spanId=#{span.context.span_id.unpack1("H*")}"
     $stdout.flush
   end
 end

--- a/integration-test/dockertest/dockertest.go
+++ b/integration-test/dockertest/dockertest.go
@@ -1,0 +1,281 @@
+package dockertest
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+type Network struct {
+	Name string
+}
+
+type Container struct {
+	ID string
+}
+
+type WaitStrategy struct {
+	typ       string
+	port      string
+	httpPath  string
+	logSubstr string
+	timeout   time.Duration
+}
+
+type ContainerFile struct {
+	Reader        io.Reader
+	ContainerPath string
+}
+
+type ContainerRequest struct {
+	Image          string
+	Platform       string
+	Cmd            []string
+	Env            map[string]string
+	ExposedPorts   []string
+	ExtraHosts     []string
+	Network        string
+	NetworkAliases []string
+	Files          []ContainerFile
+	PostStart      [][]string
+	WaitFor        *WaitStrategy
+}
+
+func WaitForHTTP(path, port string, timeout time.Duration) *WaitStrategy {
+	return &WaitStrategy{typ: "http", port: port, httpPath: path, timeout: timeout}
+}
+
+func WaitForPort(port string, timeout time.Duration) *WaitStrategy {
+	return &WaitStrategy{typ: "tcp", port: port, timeout: timeout}
+}
+
+func WaitForLog(substr string, timeout time.Duration) *WaitStrategy {
+	return &WaitStrategy{typ: "log", logSubstr: substr, timeout: timeout}
+}
+
+func CreateNetwork(t *testing.T) *Network {
+	t.Helper()
+	name := fmt.Sprintf("test-%d", time.Now().UnixNano())
+	run(t, "docker", "network", "create", name)
+	t.Cleanup(func() { runQuiet("docker", "network", "rm", name) })
+	return &Network{Name: name}
+}
+
+func StartContainer(t *testing.T, req ContainerRequest) *Container {
+	t.Helper()
+
+	args := []string{"run", "-d"}
+	if req.Platform != "" {
+		args = append(args, "--platform", req.Platform)
+	}
+	for _, port := range req.ExposedPorts {
+		args = append(args, "-p", "0:"+normalizePort(port))
+	}
+	for k, v := range req.Env {
+		args = append(args, "-e", k+"="+v)
+	}
+	for _, h := range req.ExtraHosts {
+		args = append(args, "--add-host", h)
+	}
+	if req.Network != "" {
+		args = append(args, "--network", req.Network)
+		for _, alias := range req.NetworkAliases {
+			args = append(args, "--network-alias", alias)
+		}
+	}
+	args = append(args, req.Image)
+	args = append(args, req.Cmd...)
+
+	id := strings.TrimSpace(run(t, "docker", args...))
+	c := &Container{ID: id}
+	t.Cleanup(func() {
+		if t.Failed() {
+			if out, err := exec.Command("docker", "inspect", c.ID, "--format",
+				"ExitCode={{.State.ExitCode}} OOMKilled={{.State.OOMKilled}} Running={{.State.Running}}").CombinedOutput(); err == nil {
+				t.Logf("dockertest: container %s state: %s", c.ID[:12], out)
+			}
+			if logs, err := exec.Command("docker", "logs", "--tail", "50", c.ID).CombinedOutput(); err == nil {
+				t.Logf("dockertest: container %s logs:\n%s", c.ID[:12], logs)
+			}
+		}
+		runQuiet("docker", "rm", "-f", c.ID)
+	})
+
+	for _, f := range req.Files {
+		copyFile(t, c.ID, f)
+	}
+	for _, cmd := range req.PostStart {
+		c.Exec(t, cmd)
+	}
+	if req.WaitFor != nil {
+		waitReady(t, c, req.WaitFor)
+	}
+	return c
+}
+
+func (c *Container) MappedPort(t *testing.T, containerPort string) string {
+	t.Helper()
+	output := run(t, "docker", "port", c.ID, normalizePort(containerPort))
+	line := strings.TrimSpace(strings.Split(output, "\n")[0])
+	_, hostPort, err := net.SplitHostPort(line)
+	if err != nil {
+		idx := strings.LastIndex(line, ":")
+		if idx < 0 {
+			t.Fatalf("dockertest: unexpected docker port output: %q", line)
+		}
+		hostPort = line[idx+1:]
+	}
+	return hostPort
+}
+
+func (c *Container) HostPort(t *testing.T, containerPort string) string {
+	t.Helper()
+	return "localhost:" + c.MappedPort(t, containerPort)
+}
+
+func (c *Container) Exec(t *testing.T, cmd []string) string {
+	t.Helper()
+	args := append([]string{"exec", c.ID}, cmd...)
+	return run(t, "docker", args...)
+}
+
+func (c *Container) Logs(t *testing.T) string {
+	t.Helper()
+	out, err := exec.Command("docker", "logs", c.ID).CombinedOutput()
+	if err != nil {
+		t.Fatalf("dockertest: docker logs %s failed: %v\n%s", c.ID[:12], err, out)
+	}
+	return string(out)
+}
+
+type BuildRequest struct {
+	Context    string
+	Dockerfile string
+	BuildArgs  map[string]string
+	Platform   string
+	Tag        string
+}
+
+func BuildImage(t *testing.T, req BuildRequest) string {
+	t.Helper()
+	args := []string{"build"}
+	if req.Platform != "" {
+		args = append(args, "--platform", req.Platform)
+	}
+	if req.Tag != "" {
+		args = append(args, "-t", req.Tag)
+	}
+	if req.Dockerfile != "" {
+		args = append(args, "-f", req.Dockerfile)
+	}
+	for k, v := range req.BuildArgs {
+		args = append(args, "--build-arg", k+"="+v)
+	}
+	args = append(args, req.Context)
+	run(t, "docker", args...)
+	return req.Tag
+}
+
+func BridgeGatewayIP(t *testing.T) string {
+	t.Helper()
+	output := run(t, "docker", "network", "inspect", "bridge",
+		"--format", `{{(index .IPAM.Config 0).Gateway}}`)
+	ip := strings.TrimSpace(output)
+	if ip == "" {
+		t.Fatal("dockertest: could not determine Docker bridge gateway IP")
+	}
+	return ip
+}
+
+func normalizePort(port string) string {
+	port = strings.TrimSuffix(port, "/tcp")
+	port = strings.TrimSuffix(port, "/udp")
+	return port
+}
+
+func run(t *testing.T, name string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("dockertest: %s %s failed: %v\nstdout: %s\nstderr: %s",
+			name, strings.Join(args, " "), err, stdout.String(), stderr.String())
+	}
+	return stdout.String()
+}
+
+func runQuiet(name string, args ...string) {
+	cmd := exec.Command(name, args...)
+	_ = cmd.Run()
+}
+
+func copyFile(t *testing.T, containerID string, f ContainerFile) {
+	t.Helper()
+	content, err := io.ReadAll(f.Reader)
+	if err != nil {
+		t.Fatalf("dockertest: reading file for %s: %v", f.ContainerPath, err)
+	}
+	cmd := exec.Command("docker", "exec", "-i", containerID,
+		"sh", "-c", fmt.Sprintf("cat > '%s'", f.ContainerPath))
+	cmd.Stdin = strings.NewReader(string(content))
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("dockertest: copy to %s:%s: %v\n%s", containerID[:12], f.ContainerPath, err, stderr.String())
+	}
+}
+
+func waitReady(t *testing.T, c *Container, ws *WaitStrategy) {
+	t.Helper()
+	deadline := time.Now().Add(ws.timeout)
+
+	for time.Now().Before(deadline) {
+		switch ws.typ {
+		case "http":
+			hostPort := c.MappedPort(t, ws.port)
+			addr := "localhost:" + hostPort
+			if tryHTTP(addr, ws.httpPath) {
+				return
+			}
+		case "tcp":
+			hostPort := c.MappedPort(t, ws.port)
+			addr := "localhost:" + hostPort
+			if tryTCP(addr) {
+				return
+			}
+		case "log":
+			out, err := exec.Command("docker", "logs", c.ID).CombinedOutput()
+			if err == nil && strings.Contains(string(out), ws.logSubstr) {
+				return
+			}
+		}
+		time.Sleep(time.Second)
+	}
+	t.Fatalf("dockertest: container %s not ready after %v (strategy %s)",
+		c.ID[:12], ws.timeout, ws.typ)
+}
+
+func tryHTTP(addr, path string) bool {
+	resp, err := (&http.Client{Timeout: 2 * time.Second}).Get(fmt.Sprintf("http://%s%s", addr, path))
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 400
+}
+
+func tryTCP(addr string) bool {
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}

--- a/integration-test/dockertest/dockertest_test.go
+++ b/integration-test/dockertest/dockertest_test.go
@@ -1,0 +1,251 @@
+package dockertest
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNormalizePort(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"8080/tcp", "8080"},
+		{"8080/udp", "8080"},
+		{"8080", "8080"},
+		{"443/tcp", "443"},
+	}
+	for _, tt := range tests {
+		if got := normalizePort(tt.input); got != tt.want {
+			t.Errorf("normalizePort(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestWaitForHTTPConstructor(t *testing.T) {
+	ws := WaitForHTTP("/ready", "4040/tcp", 30*time.Second)
+	if ws.typ != "http" || ws.httpPath != "/ready" || ws.port != "4040/tcp" || ws.timeout != 30*time.Second {
+		t.Errorf("unexpected WaitStrategy: %+v", ws)
+	}
+}
+
+func TestWaitForPortConstructor(t *testing.T) {
+	ws := WaitForPort("5000/tcp", 60*time.Second)
+	if ws.typ != "tcp" || ws.port != "5000/tcp" || ws.timeout != 60*time.Second {
+		t.Errorf("unexpected WaitStrategy: %+v", ws)
+	}
+}
+
+func TestTryHTTP(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthy", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/error", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	addr := ln.Addr().String()
+
+	if !tryHTTP(addr, "/healthy") {
+		t.Error("tryHTTP returned false for 200 endpoint")
+	}
+	if tryHTTP(addr, "/error") {
+		t.Error("tryHTTP returned true for 500 endpoint")
+	}
+	if tryHTTP("127.0.0.1:1", "/nope") {
+		t.Error("tryHTTP returned true for unreachable address")
+	}
+}
+
+func TestTryTCP(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	if !tryTCP(ln.Addr().String()) {
+		t.Error("tryTCP returned false for listening port")
+	}
+	if tryTCP("127.0.0.1:1") {
+		t.Error("tryTCP returned true for closed port")
+	}
+}
+
+// Tests below require Docker.
+
+func TestCreateNetwork(t *testing.T) {
+	net := CreateNetwork(t)
+	if net.Name == "" {
+		t.Fatal("network name is empty")
+	}
+	if !strings.HasPrefix(net.Name, "test-") {
+		t.Errorf("network name %q does not start with test-", net.Name)
+	}
+}
+
+func TestStartContainerAndMappedPort(t *testing.T) {
+	c := StartContainer(t, ContainerRequest{
+		Image:        "busybox:latest",
+		Cmd:          []string{"sh", "-c", "nc -l -p 8080 & sleep 60"},
+		ExposedPorts: []string{"8080/tcp"},
+		WaitFor:      WaitForPort("8080/tcp", 30*time.Second),
+	})
+	if c.ID == "" {
+		t.Fatal("container ID is empty")
+	}
+
+	port := c.MappedPort(t, "8080/tcp")
+	if port == "" {
+		t.Fatal("mapped port is empty")
+	}
+
+	hp := c.HostPort(t, "8080/tcp")
+	if !strings.HasPrefix(hp, "localhost:") {
+		t.Errorf("HostPort = %q, want localhost:* prefix", hp)
+	}
+}
+
+func TestContainerExec(t *testing.T) {
+	c := StartContainer(t, ContainerRequest{
+		Image: "busybox:latest",
+		Cmd:   []string{"sleep", "60"},
+	})
+	out := c.Exec(t, []string{"echo", "hello"})
+	if strings.TrimSpace(out) != "hello" {
+		t.Errorf("Exec output = %q, want %q", strings.TrimSpace(out), "hello")
+	}
+}
+
+func TestContainerFileInjection(t *testing.T) {
+	c := StartContainer(t, ContainerRequest{
+		Image: "busybox:latest",
+		Cmd:   []string{"sleep", "60"},
+		Files: []ContainerFile{
+			{
+				Reader:        strings.NewReader("test-content-123"),
+				ContainerPath: "/tmp/testfile.txt",
+			},
+		},
+	})
+	out := c.Exec(t, []string{"cat", "/tmp/testfile.txt"})
+	if strings.TrimSpace(out) != "test-content-123" {
+		t.Errorf("file content = %q, want %q", strings.TrimSpace(out), "test-content-123")
+	}
+}
+
+func TestContainerWithNetwork(t *testing.T) {
+	net := CreateNetwork(t)
+	c := StartContainer(t, ContainerRequest{
+		Image:          "busybox:latest",
+		Cmd:            []string{"sleep", "60"},
+		Network:        net.Name,
+		NetworkAliases: []string{"testhost"},
+	})
+	if c.ID == "" {
+		t.Fatal("container ID is empty")
+	}
+}
+
+func TestContainerHTTPWait(t *testing.T) {
+	c := StartContainer(t, ContainerRequest{
+		Image:        "busybox:latest",
+		Cmd:          []string{"sh", "-c", "while true; do echo -e 'HTTP/1.1 200 OK\\r\\n\\r\\nok' | nc -l -p 8080; done"},
+		ExposedPorts: []string{"8080/tcp"},
+		WaitFor:      WaitForHTTP("/", "8080/tcp", 30*time.Second),
+	})
+	if c.ID == "" {
+		t.Fatal("container ID is empty")
+	}
+}
+
+func TestContainerEnvVars(t *testing.T) {
+	c := StartContainer(t, ContainerRequest{
+		Image: "busybox:latest",
+		Cmd:   []string{"sleep", "60"},
+		Env: map[string]string{
+			"MY_VAR": "hello-world",
+		},
+	})
+	out := c.Exec(t, []string{"sh", "-c", "echo $MY_VAR"})
+	if strings.TrimSpace(out) != "hello-world" {
+		t.Errorf("env var = %q, want %q", strings.TrimSpace(out), "hello-world")
+	}
+}
+
+func TestContainerPostStart(t *testing.T) {
+	c := StartContainer(t, ContainerRequest{
+		Image: "busybox:latest",
+		Cmd:   []string{"sleep", "60"},
+		PostStart: [][]string{
+			{"sh", "-c", "echo post-start-ran > /tmp/hook.txt"},
+		},
+	})
+	out := c.Exec(t, []string{"cat", "/tmp/hook.txt"})
+	if strings.TrimSpace(out) != "post-start-ran" {
+		t.Errorf("PostStart hook output = %q, want %q", strings.TrimSpace(out), "post-start-ran")
+	}
+}
+
+func TestBridgeGatewayIP(t *testing.T) {
+	ip := BridgeGatewayIP(t)
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		t.Errorf("BridgeGatewayIP returned %q which is not a valid IP", ip)
+	}
+}
+
+func TestBuildImage(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM busybox:latest\nRUN echo built\n"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tag := fmt.Sprintf("dockertest-build-%d:latest", time.Now().UnixNano())
+	t.Cleanup(func() { runQuiet("docker", "rmi", tag) })
+
+	got := BuildImage(t, BuildRequest{
+		Context:    dir,
+		Dockerfile: filepath.Join(dir, "Dockerfile"),
+		Tag:        tag,
+	})
+	if got != tag {
+		t.Errorf("BuildImage returned %q, want %q", got, tag)
+	}
+}
+
+func TestBuildImageWithArgs(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM busybox:latest\nARG TEST_ARG=default\nRUN echo $TEST_ARG > /tmp/arg.txt\n"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tag := fmt.Sprintf("dockertest-buildargs-%d:latest", time.Now().UnixNano())
+	t.Cleanup(func() { runQuiet("docker", "rmi", tag) })
+
+	BuildImage(t, BuildRequest{
+		Context:    dir,
+		Dockerfile: filepath.Join(dir, "Dockerfile"),
+		Tag:        tag,
+		BuildArgs:  map[string]string{"TEST_ARG": "custom-value"},
+	})
+
+	c := StartContainer(t, ContainerRequest{
+		Image: tag,
+		Cmd:   []string{"cat", "/tmp/arg.txt"},
+	})
+	_ = c // container runs cat and exits; if it didn't fail, the build worked
+}

--- a/integration-test/go.mod
+++ b/integration-test/go.mod
@@ -1,0 +1,5 @@
+module pyroscope-otel-integration-test
+
+go 1.26
+
+toolchain go1.26.4

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -101,10 +101,14 @@ type spanCheck struct {
 	// pyroscope "span" label.
 	span string
 	// mustContain frames that have to appear in the span-scoped profile.
+	//
+	// Note: we only assert positive containment. A non-empty profile for
+	// {span="<name>"} already proves the SpanProcessor labels profiles per
+	// span (without the label the query would return nothing). We avoid
+	// negative ("must not contain") assertions because the CPU profiler can
+	// attribute a sample taken at a span boundary to the adjacent span,
+	// which would make such assertions flaky.
 	mustContain []string
-	// mustNotContain frames that must NOT appear, proving the profile is
-	// scoped to this span only.
-	mustNotContain []string
 }
 
 // TestSpanProfiles verifies that Pyroscope::Otel::SpanProcessor labels CPU
@@ -122,9 +126,8 @@ func TestSpanProfiles(t *testing.T) {
 
 	checks := []spanCheck{
 		{
-			span:           "BikeHandler",
-			mustContain:    []string{"find_nearest_vehicle"},
-			mustNotContain: []string{"check_driver_availability"},
+			span:        "BikeHandler",
+			mustContain: []string{"find_nearest_vehicle"},
 		},
 		{
 			span:        "CarHandler",
@@ -163,11 +166,6 @@ func TestSpanProfiles(t *testing.T) {
 				}
 				t.Logf("[%s] last collapsed profile:\n%s", check.span, lastCollapsed)
 				t.FailNow()
-			}
-
-			for _, f := range check.mustNotContain {
-				require.False(t, strings.Contains(lastCollapsed, f),
-					"[%s] frame %q must not appear in span-scoped profile:\n%s", check.span, f, lastCollapsed)
 			}
 		})
 	}

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -49,10 +50,10 @@ func buildAppImage(t *testing.T, rubyVersion string) string {
 	return tag
 }
 
-func startApp(t *testing.T, net *dockertest.Network, image, svcName string) {
+func startApp(t *testing.T, net *dockertest.Network, image, svcName string) *dockertest.Container {
 	t.Helper()
 	t.Logf("starting app %s (service_name=%s) ...", image, svcName)
-	dockertest.StartContainer(t, dockertest.ContainerRequest{
+	return dockertest.StartContainer(t, dockertest.ContainerRequest{
 		Image:          image,
 		Platform:       "linux/amd64",
 		Network:        net.Name,
@@ -78,6 +79,52 @@ func queryProfile(t *testing.T, pyroscopeURL, labelSelector string) (string, err
 			Start:         from.UnixMilli(),
 			End:           to.UnixMilli(),
 			LabelSelector: labelSelector,
+			MaxNodes:      &maxNodes,
+			Format:        querier.ProfileFormat_PROFILE_FORMAT_TREE,
+		})
+	if err != nil {
+		return "", err
+	}
+	if len(resp.Tree) == 0 {
+		return "", nil
+	}
+	tt, err := model.UnmarshalTree(resp.Tree)
+	if err != nil {
+		return "", err
+	}
+	buf := bytes.NewBuffer(nil)
+	tt.WriteCollapsed(buf)
+	return buf.String(), nil
+}
+
+var spanIDRe = regexp.MustCompile(`spanId=([0-9a-fA-F]{16})`)
+
+// extractSpanID returns the first span ID logged by the app in the form
+// "spanId=<16-hex>".
+func extractSpanID(logs string) (string, error) {
+	matches := spanIDRe.FindStringSubmatch(logs)
+	if len(matches) < 2 {
+		return "", fmt.Errorf("spanId not found in logs")
+	}
+	return matches[1], nil
+}
+
+// queryProfileBySpanID queries a span-scoped CPU profile using SelectMergeSpanProfile,
+// selecting samples tagged with the given span ID, and returns the collapsed tree.
+func queryProfileBySpanID(t *testing.T, pyroscopeURL, labelSelector, spanID string) (string, error) {
+	t.Helper()
+	qc := querier.NewClient(http.DefaultClient, pyroscopeURL)
+
+	to := time.Now()
+	from := to.Add(-time.Hour)
+	maxNodes := int64(65536)
+	resp, err := qc.SelectMergeSpanProfile(context.Background(),
+		&querier.SelectMergeSpanProfileRequest{
+			ProfileTypeID: cpuProfileType,
+			Start:         from.UnixMilli(),
+			End:           to.UnixMilli(),
+			LabelSelector: labelSelector,
+			SpanSelector:  []string{spanID},
 			MaxNodes:      &maxNodes,
 			Format:        querier.ProfileFormat_PROFILE_FORMAT_TREE,
 		})
@@ -168,5 +215,67 @@ func TestSpanProfiles(t *testing.T) {
 				t.FailNow()
 			}
 		})
+	}
+}
+
+// TestSpanProfilesBySpanID verifies that a CPU profile scoped to a single span
+// can be queried by its span ID via Pyroscope's SelectMergeSpanProfile, proving
+// that Pyroscope::Otel::SpanProcessor tags samples with the OpenTelemetry span
+// ID (the "profile_id" label).
+func TestSpanProfilesBySpanID(t *testing.T) {
+	net := dockertest.CreateNetwork(t)
+
+	pyroscopeURL := startPyroscope(t, net)
+	t.Logf("pyroscope URL: %s", pyroscopeURL)
+
+	image := buildAppImage(t, envRubyVersion())
+	svcName := serviceName()
+	appC := startApp(t, net, image, svcName)
+
+	var spanID string
+	ok := require.Eventually(t, func() bool {
+		var err error
+		spanID, err = extractSpanID(appC.Logs(t))
+		if err != nil {
+			t.Logf("span ID not in logs yet: %s", err)
+			return false
+		}
+		return true
+	}, time.Minute, time.Second)
+	if !ok {
+		t.Fatal("failed to extract span ID from app logs")
+	}
+	t.Logf("extracted span ID: %s", spanID)
+
+	labelSelector := fmt.Sprintf(`{service_name="%s"}`, svcName)
+	mustContain := []string{"find_nearest_vehicle", "check_driver_availability"}
+
+	var lastCollapsed string
+	var lastErr error
+	ok = require.Eventually(t, func() bool {
+		lastCollapsed, lastErr = queryProfileBySpanID(t, pyroscopeURL, labelSelector, spanID)
+		if lastErr != nil {
+			t.Logf("query error: %s", lastErr)
+			return false
+		}
+		if lastCollapsed == "" {
+			t.Logf("empty profile")
+			return false
+		}
+		for _, f := range mustContain {
+			if !strings.Contains(lastCollapsed, f) {
+				t.Logf("frame %q not found yet", f)
+				return false
+			}
+		}
+		return true
+	}, 3*time.Minute, 5*time.Second)
+
+	if !ok {
+		if lastErr != nil {
+			t.Logf("last error: %s", lastErr)
+		}
+		t.Logf("last collapsed profile:\n%s", lastCollapsed)
+		t.FailNow()
 	}
 }

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -155,7 +155,7 @@ func TestSpanProfiles(t *testing.T) {
 					}
 				}
 				return true
-			}, 3*time.Minute, 5*time.Second)
+			}, 45*time.Second, 5*time.Second)
 
 			if !ok {
 				if lastErr != nil {

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -155,7 +155,7 @@ func TestSpanProfiles(t *testing.T) {
 					}
 				}
 				return true
-			}, 45*time.Second, 5*time.Second)
+			}, 3*time.Minute, 5*time.Second)
 
 			if !ok {
 				if lastErr != nil {

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -1,0 +1,174 @@
+package integrationtest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"pyroscope-otel-integration-test/api/querier"
+	"pyroscope-otel-integration-test/dockertest"
+	"pyroscope-otel-integration-test/pyroscope/model"
+	"pyroscope-otel-integration-test/require"
+)
+
+const pyroscopeImage = "grafana/pyroscope:1.18.0@sha256:e7edae4fd99dbb8695a1e03d7db96ab247630cf83842407908922b2f66aafc6a"
+
+const cpuProfileType = "process_cpu:cpu:nanoseconds:cpu:nanoseconds"
+
+func startPyroscope(t *testing.T, net *dockertest.Network) string {
+	t.Helper()
+	t.Log("starting pyroscope...")
+	c := dockertest.StartContainer(t, dockertest.ContainerRequest{
+		Image:          pyroscopeImage,
+		ExposedPorts:   []string{"4040/tcp"},
+		Network:        net.Name,
+		NetworkAliases: []string{"pyroscope"},
+		WaitFor:        dockertest.WaitForHTTP("/ready", "4040/tcp", 60*time.Second),
+	})
+	return fmt.Sprintf("http://%s", c.HostPort(t, "4040/tcp"))
+}
+
+func buildAppImage(t *testing.T, rubyVersion string) string {
+	t.Helper()
+	tag := fmt.Sprintf("pyroscope-otel-ruby-itest-%s:latest", rubyVersion)
+	t.Logf("building app image %s ...", tag)
+	dockertest.BuildImage(t, dockertest.BuildRequest{
+		Context:    repoRoot(),
+		Dockerfile: filepath.Join(repoRoot(), "integration-test", "app", "Dockerfile"),
+		Platform:   "linux/amd64",
+		Tag:        tag,
+		BuildArgs: map[string]string{
+			"RUBY_VERSION": rubyVersion,
+		},
+	})
+	return tag
+}
+
+func startApp(t *testing.T, net *dockertest.Network, image, svcName string) {
+	t.Helper()
+	t.Logf("starting app %s (service_name=%s) ...", image, svcName)
+	dockertest.StartContainer(t, dockertest.ContainerRequest{
+		Image:          image,
+		Platform:       "linux/amd64",
+		Network:        net.Name,
+		NetworkAliases: []string{"rideshare"},
+		Env: map[string]string{
+			"PYROSCOPE_APPLICATION_NAME": svcName,
+			"PYROSCOPE_SERVER_ADDRESS":   "http://pyroscope:4040",
+			"REGION":                     "us-east",
+		},
+	})
+}
+
+func queryProfile(t *testing.T, pyroscopeURL, labelSelector string) (string, error) {
+	t.Helper()
+	qc := querier.NewClient(http.DefaultClient, pyroscopeURL)
+
+	to := time.Now()
+	from := to.Add(-time.Hour)
+	maxNodes := int64(65536)
+	resp, err := qc.SelectMergeStacktraces(context.Background(),
+		&querier.SelectMergeStacktracesRequest{
+			ProfileTypeID: cpuProfileType,
+			Start:         from.UnixMilli(),
+			End:           to.UnixMilli(),
+			LabelSelector: labelSelector,
+			MaxNodes:      &maxNodes,
+			Format:        querier.ProfileFormat_PROFILE_FORMAT_TREE,
+		})
+	if err != nil {
+		return "", err
+	}
+	if len(resp.Tree) == 0 {
+		return "", nil
+	}
+	tt, err := model.UnmarshalTree(resp.Tree)
+	if err != nil {
+		return "", err
+	}
+	buf := bytes.NewBuffer(nil)
+	tt.WriteCollapsed(buf)
+	return buf.String(), nil
+}
+
+type spanCheck struct {
+	// span is the OpenTelemetry span name the SpanProcessor attaches as the
+	// pyroscope "span" label.
+	span string
+	// mustContain frames that have to appear in the span-scoped profile.
+	mustContain []string
+	// mustNotContain frames that must NOT appear, proving the profile is
+	// scoped to this span only.
+	mustNotContain []string
+}
+
+// TestSpanProfiles verifies that Pyroscope::Otel::SpanProcessor labels CPU
+// profiles with the OpenTelemetry span name, so that profiling data can be
+// queried per span.
+func TestSpanProfiles(t *testing.T) {
+	net := dockertest.CreateNetwork(t)
+
+	pyroscopeURL := startPyroscope(t, net)
+	t.Logf("pyroscope URL: %s", pyroscopeURL)
+
+	image := buildAppImage(t, envRubyVersion())
+	svcName := serviceName()
+	startApp(t, net, image, svcName)
+
+	checks := []spanCheck{
+		{
+			span:           "BikeHandler",
+			mustContain:    []string{"find_nearest_vehicle"},
+			mustNotContain: []string{"check_driver_availability"},
+		},
+		{
+			span:        "CarHandler",
+			mustContain: []string{"find_nearest_vehicle", "check_driver_availability"},
+		},
+	}
+
+	for _, check := range checks {
+		check := check
+		t.Run(check.span, func(t *testing.T) {
+			labelSelector := fmt.Sprintf(`{service_name="%s",span="%s"}`, svcName, check.span)
+			var lastCollapsed string
+			var lastErr error
+			ok := require.Eventually(t, func() bool {
+				lastCollapsed, lastErr = queryProfile(t, pyroscopeURL, labelSelector)
+				if lastErr != nil {
+					t.Logf("[%s] query error: %s", check.span, lastErr)
+					return false
+				}
+				if lastCollapsed == "" {
+					t.Logf("[%s] empty profile", check.span)
+					return false
+				}
+				for _, f := range check.mustContain {
+					if !strings.Contains(lastCollapsed, f) {
+						t.Logf("[%s] frame %q not found yet", check.span, f)
+						return false
+					}
+				}
+				return true
+			}, 3*time.Minute, 5*time.Second)
+
+			if !ok {
+				if lastErr != nil {
+					t.Logf("[%s] last error: %s", check.span, lastErr)
+				}
+				t.Logf("[%s] last collapsed profile:\n%s", check.span, lastCollapsed)
+				t.FailNow()
+			}
+
+			for _, f := range check.mustNotContain {
+				require.False(t, strings.Contains(lastCollapsed, f),
+					"[%s] frame %q must not appear in span-scoped profile:\n%s", check.span, f, lastCollapsed)
+			}
+		})
+	}
+}

--- a/integration-test/matrix.go
+++ b/integration-test/matrix.go
@@ -1,0 +1,29 @@
+package integrationtest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+func envOrDefault(key, defaultValue string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultValue
+}
+
+func envRubyVersion() string { return envOrDefault("RUBY_VERSION", "3.3.9") }
+
+// serviceName returns a unique pyroscope application name per test run so that
+// profiles from different runs do not collide in a shared pyroscope instance.
+func serviceName() string {
+	return fmt.Sprintf("rideshare.ruby.app.%d", time.Now().UnixNano())
+}
+
+func repoRoot() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Dir(filepath.Dir(filename))
+}

--- a/integration-test/pyroscope/minheap/minheap.go
+++ b/integration-test/pyroscope/minheap/minheap.go
@@ -1,0 +1,51 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package minheap
+
+func Push(h []int64, x int64) []int64 {
+	h = append(h, x)
+	up(h, len(h)-1)
+	return h
+}
+
+func Pop(h []int64) []int64 {
+	n := len(h) - 1
+	h[0], h[n] = h[n], h[0]
+	down(h, 0, n)
+	n = len(h)
+	h = h[0 : n-1]
+	return h
+}
+
+func up(h []int64, j int) {
+	for {
+		i := (j - 1) / 2 // parent
+		if i == j || (h[j] >= h[i]) {
+			break
+		}
+		h[i], h[j] = h[j], h[i]
+		j = i
+	}
+}
+
+func down(h []int64, i0, n int) bool {
+	i := i0
+	for {
+		j1 := 2*i + 1
+		if j1 >= n || j1 < 0 { // j1 < 0 after int overflow
+			break
+		}
+		j := j1 // left child
+		if j2 := j1 + 1; j2 < n && h[j2] < h[j1] {
+			j = j2 // = 2*i + 2  // right child
+		}
+		if h[j] >= h[i] {
+			break
+		}
+		h[i], h[j] = h[j], h[i]
+		i = j
+	}
+	return i > i0
+}

--- a/integration-test/pyroscope/model/tree.go
+++ b/integration-test/pyroscope/model/tree.go
@@ -1,0 +1,340 @@
+package model
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"slices"
+	"sort"
+	"strings"
+
+	"pyroscope-otel-integration-test/pyroscope/minheap"
+)
+
+type Tree struct {
+	root []*node
+}
+
+type node struct {
+	parent      *node
+	children    []*node
+	self, total int64
+	name        string
+}
+
+func (t *Tree) Total() (v int64) {
+	for _, n := range t.root {
+		v += n.total
+	}
+	return v
+}
+
+func (t *Tree) InsertStack(v int64, stack ...string) {
+	if v <= 0 {
+		return
+	}
+	r := &node{children: t.root}
+	n := r
+	for s := range stack {
+		name := stack[s]
+		n.total += v
+		// Inlined node.insert
+		i, j := 0, len(n.children)
+		for i < j {
+			h := int(uint(i+j) >> 1)
+			if n.children[h].name < name {
+				i = h + 1
+			} else {
+				j = h
+			}
+		}
+		if i < len(n.children) && n.children[i].name == name {
+			n = n.children[i]
+		} else {
+			child := &node{parent: n, name: name}
+			n.children = append(n.children, child)
+			copy(n.children[i+1:], n.children[i:])
+			n.children[i] = child
+			n = child
+		}
+	}
+	// Leaf.
+	n.total += v
+	n.self += v
+	t.root = r.children
+}
+
+func (t *Tree) WriteCollapsed(dst io.Writer) {
+	t.IterateStacks(func(_ string, self int64, stack []string) {
+		slices.Reverse(stack)
+		_, _ = fmt.Fprintf(dst, "%s %d\n", strings.Join(stack, ";"), self)
+	})
+}
+
+func (t *Tree) IterateStacks(cb func(name string, self int64, stack []string)) {
+	s := 1024
+	if s < len(t.root) {
+		s += len(t.root)
+	}
+	nodes := make([]*node, len(t.root), s)
+	stack := make([]string, 0, 64)
+	copy(nodes, t.root)
+	for len(nodes) > 0 {
+		n := nodes[0]
+		self := n.self
+		label := n.name
+		if self > 0 {
+			current := n
+			stack = stack[:0]
+			for current != nil && current.parent != nil {
+				stack = append(stack, current.name)
+				current = current.parent
+			}
+			cb(label, self, stack)
+		}
+		nodes = nodes[1:]
+		nodes = append(nodes, n.children...)
+	}
+}
+
+// Default Depth First Search slice capacity. The value should be equal
+// to the number of all the siblings of the tree leaf ascendants.
+//
+// Chosen empirically. For very deep stacks (>128), it's likely that the
+// slice will grow to 1-4K nodes, depending on the trace branching.
+const defaultDFSSize = 128
+
+func (t *Tree) Merge(src *Tree) {
+	if t.Total() == 0 && src.Total() > 0 {
+		*t = *src
+		return
+	}
+	if src.Total() == 0 {
+		return
+	}
+
+	srcNodes := make([]*node, 0, defaultDFSSize)
+	srcRoot := &node{children: src.root}
+	srcNodes = append(srcNodes, srcRoot)
+
+	dstNodes := make([]*node, 0, defaultDFSSize)
+	dstRoot := &node{children: t.root}
+	dstNodes = append(dstNodes, dstRoot)
+
+	var st, dt *node
+	for len(srcNodes) > 0 {
+		st, srcNodes = srcNodes[len(srcNodes)-1], srcNodes[:len(srcNodes)-1]
+		dt, dstNodes = dstNodes[len(dstNodes)-1], dstNodes[:len(dstNodes)-1]
+
+		dt.self += st.self
+		dt.total += st.total
+
+		for _, srcChildNode := range st.children {
+			// Note that we don't copy the name, but reference it.
+			dstChildNode := dt.insert(srcChildNode.name)
+			srcNodes = append(srcNodes, srcChildNode)
+			dstNodes = append(dstNodes, dstChildNode)
+		}
+	}
+
+	t.root = dstRoot.children
+}
+
+func (t *Tree) FormatNodeNames(fn func(string) string) {
+	nodes := make([]*node, 0, defaultDFSSize)
+	nodes = append(nodes, &node{children: t.root})
+	var n *node
+	var fix bool
+	for len(nodes) > 0 {
+		n, nodes = nodes[len(nodes)-1], nodes[:len(nodes)-1]
+		m := n.name
+		n.name = fn(m)
+		if m != n.name {
+			fix = true
+		}
+		nodes = append(nodes, n.children...)
+	}
+	if !fix {
+		return
+	}
+	t.Fix()
+}
+
+// Fix re-establishes order of nodes and merges duplicates.
+func (t *Tree) Fix() {
+	if len(t.root) == 0 {
+		return
+	}
+	r := &node{children: t.root}
+	for _, n := range r.children {
+		n.parent = r
+	}
+	nodes := make([][]*node, 0, defaultDFSSize)
+	nodes = append(nodes, r.children)
+	var n []*node
+	for len(nodes) > 0 {
+		n, nodes = nodes[len(nodes)-1], nodes[:len(nodes)-1]
+		if len(n) == 0 {
+			continue
+		}
+		sort.Slice(n, func(i, j int) bool {
+			return n[i].name < n[j].name
+		})
+		p := n[0]
+		j := 1
+		for _, c := range n[1:] {
+			if p.name == c.name {
+				for _, x := range c.children {
+					x.parent = p
+				}
+				p.children = append(p.children, c.children...)
+				p.total += c.total
+				p.self += c.self
+				continue
+			}
+			p = c
+			n[j] = c
+			j++
+		}
+		n = n[:j]
+		for _, c := range n {
+			c.parent.children = n
+			nodes = append(nodes, c.children)
+		}
+	}
+	t.root = r.children
+}
+
+func (n *node) String() string {
+	return fmt.Sprintf("{%s: self %d total %d}", n.name, n.self, n.total)
+}
+
+func (n *node) insert(name string) *node {
+	i := sort.Search(len(n.children), func(i int) bool {
+		return n.children[i].name >= name
+	})
+	if i < len(n.children) && n.children[i].name == name {
+		return n.children[i]
+	}
+	// We don't clone the name: it is caller responsibility
+	// to maintain the memory ownership.
+	child := &node{parent: n, name: name}
+	n.children = append(n.children, child)
+	copy(n.children[i+1:], n.children[i:])
+	n.children[i] = child
+	return child
+}
+
+// minValue returns the minimum "total" value a node in a tree has to have to show up in
+// the resulting flamegraph
+func (t *Tree) minValue(maxNodes int64) int64 {
+	if maxNodes < 1 {
+		return 0
+	}
+	nodes := make([]*node, 0, max(int64(len(t.root)), defaultDFSSize))
+	treeSize := t.size(nodes)
+	if treeSize <= maxNodes {
+		return 0
+	}
+
+	h := make([]int64, 0, maxNodes)
+
+	nodes = append(nodes[:0], t.root...)
+	var n *node
+	for len(nodes) > 0 {
+		last := len(nodes) - 1
+		n, nodes = nodes[last], nodes[:last]
+		if len(h) >= int(maxNodes) {
+			if n.total > h[0] {
+				h = minheap.Pop(h)
+			} else {
+				continue
+			}
+		}
+		h = minheap.Push(h, n.total)
+		nodes = append(nodes, n.children...)
+	}
+
+	if len(h) < int(maxNodes) {
+		return 0
+	}
+
+	return h[0]
+}
+
+// size reports number of nodes the tree consists of.
+// Provided buffer used for DFS traversal.
+func (t *Tree) size(buf []*node) int64 {
+	nodes := append(buf, t.root...)
+	var s int64
+	var n *node
+	for len(nodes) > 0 {
+		last := len(nodes) - 1
+		n, nodes = nodes[last], nodes[:last]
+		nodes = append(nodes, n.children...)
+		s++
+	}
+	return s
+}
+
+var errMalformedTreeBytes = fmt.Errorf("malformed tree bytes")
+
+const estimateBytesPerNode = 16 // Chosen empirically.
+
+func UnmarshalTree(b []byte) (*Tree, error) {
+	t := new(Tree)
+	if len(b) < 2 {
+		return t, nil
+	}
+	size := estimateBytesPerNode
+	if e := len(b) / estimateBytesPerNode; e > estimateBytesPerNode {
+		size = e
+	}
+	parents := make([]*node, 1, size)
+	// Virtual root node.
+	root := new(node)
+	parents[0] = root
+	var parent *node
+	var offset int
+
+	for len(parents) > 0 {
+		parent, parents = parents[len(parents)-1], parents[:len(parents)-1]
+		nameLen, o := binary.Uvarint(b[offset:])
+		if o < 0 {
+			return nil, errMalformedTreeBytes
+		}
+		offset += o
+		// Note that we allocate a string, instead of referencing b's capacity.
+		name := string(b[offset : offset+int(nameLen)])
+		offset += int(nameLen)
+		value, o := binary.Uvarint(b[offset:])
+		if o < 0 {
+			return nil, errMalformedTreeBytes
+		}
+		offset += o
+		childrenLen, o := binary.Uvarint(b[offset:])
+		if o < 0 {
+			return nil, errMalformedTreeBytes
+		}
+		offset += o
+
+		n := parent.insert(name)
+		n.children = make([]*node, 0, childrenLen)
+		n.self = int64(value)
+
+		pn := n
+		for pn.parent != nil {
+			pn.total += n.self
+			pn = pn.parent
+		}
+
+		for i := uint64(0); i < childrenLen; i++ {
+			parents = append(parents, n)
+		}
+	}
+
+	// Remove the virtual root.
+	t.root = root.children[0].children
+
+	return t, nil
+}

--- a/integration-test/require/equal.go
+++ b/integration-test/require/equal.go
@@ -1,0 +1,14 @@
+package require
+
+import (
+	"testing"
+)
+
+func Equal[T comparable](t *testing.T, expected T, actual T) {
+	t.Helper()
+
+	if expected == actual {
+		return
+	}
+	t.Fatalf("expected %+v\nactual %+v", expected, actual)
+}

--- a/integration-test/require/eventually.go
+++ b/integration-test/require/eventually.go
@@ -1,0 +1,39 @@
+package require
+
+import (
+	"testing"
+	"time"
+)
+
+func Eventually(t *testing.T, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
+	t.Helper()
+
+	ch := make(chan bool, 1)
+	checkCond := func() { ch <- condition() }
+
+	timer := time.NewTimer(waitFor)
+	defer timer.Stop()
+
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
+
+	var tickC <-chan time.Time
+
+	// Check the condition once first on the initial call.
+	go checkCond()
+
+	for {
+		select {
+		case <-timer.C:
+			return Fail(t, "Condition never satisfied", msgAndArgs...)
+		case <-tickC:
+			tickC = nil
+			go checkCond()
+		case v := <-ch:
+			if v {
+				return true
+			}
+			tickC = ticker.C
+		}
+	}
+}

--- a/integration-test/require/fail.go
+++ b/integration-test/require/fail.go
@@ -1,0 +1,29 @@
+package require
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Fail(t *testing.T, failureMessage string, msgAndArgs ...interface{}) bool {
+	t.Helper()
+	t.Fatalf("\n%s\n%s", failureMessage, messageFromMsgAndArgs(msgAndArgs...))
+	return false
+}
+
+func messageFromMsgAndArgs(msgAndArgs ...interface{}) string {
+	if len(msgAndArgs) == 0 || msgAndArgs == nil {
+		return ""
+	}
+	if len(msgAndArgs) == 1 {
+		msg := msgAndArgs[0]
+		if msgAsStr, ok := msg.(string); ok {
+			return msgAsStr
+		}
+		return fmt.Sprintf("%+v", msg)
+	}
+	if len(msgAndArgs) > 1 {
+		return fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...)
+	}
+	return ""
+}

--- a/integration-test/require/never.go
+++ b/integration-test/require/never.go
@@ -1,0 +1,39 @@
+package require
+
+import (
+	"testing"
+	"time"
+)
+
+func Never(t *testing.T, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
+	t.Helper()
+
+	ch := make(chan bool, 1)
+	checkCond := func() { ch <- condition() }
+
+	timer := time.NewTimer(waitFor)
+	defer timer.Stop()
+
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
+
+	var tickC <-chan time.Time
+
+	// Check the condition once first on the initial call.
+	go checkCond()
+
+	for {
+		select {
+		case <-timer.C:
+			return true
+		case <-tickC:
+			tickC = nil
+			go checkCond()
+		case v := <-ch:
+			if v {
+				return Fail(t, "Condition satisfied", msgAndArgs...)
+			}
+			tickC = ticker.C
+		}
+	}
+}

--- a/integration-test/require/noerror.go
+++ b/integration-test/require/noerror.go
@@ -1,0 +1,13 @@
+package require
+
+import (
+	"testing"
+)
+
+func NoError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		return
+	}
+	t.Fatalf("%s", err.Error())
+}

--- a/integration-test/require/truefalse.go
+++ b/integration-test/require/truefalse.go
@@ -1,0 +1,21 @@
+package require
+
+import (
+	"testing"
+)
+
+func True(t *testing.T, value bool, msgAndArgs ...interface{}) {
+	t.Helper()
+	if value {
+		return
+	}
+	Fail(t, "Expected true", msgAndArgs...)
+}
+
+func False(t *testing.T, value bool, msgAndArgs ...interface{}) {
+	t.Helper()
+	if !value {
+		return
+	}
+	Fail(t, "Expected false", msgAndArgs...)
+}


### PR DESCRIPTION
## Summary

- Adds a zero-dependency Go integration test (modeled on `pyroscope-java` and `pyroscope-dotnet`) under `integration-test/`, driving the `docker` CLI to validate the gem end to end.
- Builds a small Ruby app against the **local** `pyroscope-otel` gem (path gem, run under `bundle exec`), runs it next to a Pyroscope server on a Docker network, and asserts that `Pyroscope::Otel::SpanProcessor` labels CPU profiles per OpenTelemetry span.
- The test queries Pyroscope by the `span` label and checks span-scoped frames: `BikeHandler` contains `find_nearest_vehicle` but not `check_driver_availability`, while `CarHandler` contains both.
- Adds `.github/workflows/integration_test.yml` with `discover` / `unit-test` / `test` jobs, crossing the discovered Go tests with a Ruby-version matrix (`3.2.2`, `3.3.9`, `3.4.1`).

### Layout

- `integration-test/dockertest`, `api/querier`, `pyroscope/model`, `pyroscope/minheap`, `require` — copied harness (stdlib only).
- `integration-test/app` — Dockerfile + Gemfile + `lib/main.rb` workload emitting CPU load inside named spans.
- `integration-test/integration_test.go` — the test; `matrix.go` — env/repo-root helpers.
- Go `1.26` / toolchain `go1.26.4`, no Go dependencies.

## Test plan

- [x] `go build ./...` and `go vet ./...` pass
- [x] `go test ./dockertest/` (non-docker unit tests) pass
- [x] Full `TestSpanProfiles` passes locally with Docker
- [ ] CI integration matrix is green